### PR TITLE
feat: add parser options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = {
+    parserOptions: {
+        'ecmaVersion': 6,
+        'sourceType': 'module'
+    },
     env: {
         es6: true,
         node: true


### PR DESCRIPTION
fixes `error  Parsing error: 'import' and 'export' may appear only with 'sourceType: module'`
