### PR TITLE
feat: switch indent rule to two spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ module.exports = {
     'comma-style': 'error',
     'eol-last': 'error',
     'func-call-spacing': 'error',
-    indent: ['error', 4, { SwitchCase: 1 }],
+    indent: ['error', 2, { SwitchCase: 1 }],
     'key-spacing': 'error',
     'keyword-spacing': 'error',
     'new-parens': 'error',

--- a/test/not-ok.js
+++ b/test/not-ok.js
@@ -8,14 +8,14 @@ var x;
 useIt(x);
 
 x = {
-    'useless': 'quotes'
+  'useless': 'quotes'
 };
 
 var y = 1, z;
 useIt(y, z);
 
 function A() {
-    this.x = 1;
+  this.x = 1;
 }
 
 new A();
@@ -26,7 +26,7 @@ new A();
 
 // use this function to mark a variable as used
 function useIt(...vals) {
-    return vals;
+  return vals;
 }
 
 

--- a/test/ok.js
+++ b/test/ok.js
@@ -12,16 +12,16 @@ c = a + b;
 useIt(c);
 
 function A() {
-    this.x = 1;
+  this.x = 1;
 }
 
 useIt(new A());
 
 (function f() {
-    return 1;
+  return 1;
 })();
 
 // use this function to mark a variable as used
 function useIt(...vals) {
-    return vals;
+  return vals;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ assert.strictEqual(okResult.length, 0, 'ok.js should have no error: ' + util.for
 const notOkResult = linter.verify(notOk, config);
 const errors = notOkResult.map(error => error.ruleId).sort();
 assert.deepStrictEqual(errors, [
+    'indent',
     'no-console',
     'no-multiple-empty-lines',
     'no-new',


### PR DESCRIPTION
Reasons for changing:
- Most common style in the JS community
- Easier to read (especially when using react JSX)
- Compatibility with prettier

We didn't really use 4 spaces by choice but because it was Webstorm's default and now we don't use it anymore...